### PR TITLE
Add initial fuzz testing

### DIFF
--- a/tests/fuzz_private_key.py
+++ b/tests/fuzz_private_key.py
@@ -1,0 +1,36 @@
+import sys
+import atheris
+
+with atheris.instrument_imports():
+    from ellipticcurve import Ecdsa, Signature, PublicKey, PrivateKey
+
+
+@atheris.instrument_func
+def TestOneInput(input_bytes):
+    fdp = atheris.FuzzedDataProvider(input_bytes)
+
+    privateKey1 = PrivateKey()
+    publicKey1 = privateKey1.publicKey()
+
+    privateKeyPem = privateKey1.toPem()
+    publicKeyPem = publicKey1.toPem()
+
+    privateKey2 = PrivateKey.fromPem(privateKeyPem)
+    publicKey2 = PublicKey.fromPem(publicKeyPem)
+
+    message = fdp.ConsumeUnicode(sys.maxsize)
+
+    signatureBase64 = Ecdsa.sign(message=message,
+                                 privateKey=privateKey2).toBase64()
+
+    signature = Signature.fromBase64(signatureBase64)
+    assert(Ecdsa.verify(message=message, signature=signature, publicKey=publicKey2))
+
+
+def main():
+    atheris.Setup(sys.argv, TestOneInput, enable_python_coverage=True)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Hi,

I was wondering if you would be interesting in fuzzing ecdsa-python by way of OSS-Fuzz? In this PR I included an initial fuzz driver that can be run with Atheris and also done an initial integration on OSS-Fuzz in this PR https://github.com/google/oss-fuzz/pull/7498 

Essentially, OSS-Fuzz is a free service run by Google that performs continuous fuzzing of important open source projects. If you're unfamiliar with fuzzing, then it's a technique for finding security and reliability issues by way of sophisticated stress testing. In the case of Python what we will often find is uncaught exceptions and in the even of native extensions memory corruption issues. When integrating with OSS-Fuzz, the only expectation is that bugs will be fixed. This is not a "hard" requirement in that no one enforces this and the main point is if bugs are not fixed then it is a waste of resources to run the fuzzers, which we would like to avoid.

If you would like to integrate, the only thing I need is as list of email(s) that will get access to the data produced by OSS-Fuzz, such as bug reports, coverage reports and more stats. Notice the emails affiliated with the project will be public in the OSS-Fuzz repo, as they will be part of a configuration file.